### PR TITLE
Use --cpu:wasm32 in config.nims

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -7,7 +7,7 @@ when defined(emscripten):
   --nimcache:tmp # Store intermediate files close by in the ./tmp dir.
 
   --os:linux # Emscripten pretends to be linux.
-  --cpu:i386 # Emscripten is 32bits.
+  --cpu:wasm32 # Emscripten is 32bits.
   --cc:clang # Emscripten is very close to clang, so we ill replace it.
   when defined(windows):
     --clang.exe:emcc.bat  # Replace C

--- a/config.nims
+++ b/config.nims
@@ -24,5 +24,7 @@ when defined(emscripten):
   --gc:arc # GC:arc is friendlier with crazy platforms.
   --exceptions:goto # Goto exceptions are friendlier with crazy platforms.
 
+  --define:useMalloc
+
   # Pass this to Emscripten linker to generate html file scaffold for us.
   switch("passL", "-o examples/web/index.html -s USE_WEBGL2=1 --shell-file examples/web/shell_minimal.html")


### PR DESCRIPTION
This is apparently a better --cpu option for webassembly. It also defines `useMalloc` because using C's allocator seems to work better with emscripten than nim's built-in allocator.